### PR TITLE
fix popen thread safety

### DIFF
--- a/gen/FreeBSD/popen.c
+++ b/gen/FreeBSD/popen.c
@@ -173,8 +173,10 @@ popen(command, type)
 		}
 		(void)posix_spawn_file_actions_addclose(&file_actions, pdes[1]);
 	}
+	THREAD_LOCK();
 	SLIST_FOREACH(p, &pidlist, next)
 		(void)posix_spawn_file_actions_addclose(&file_actions, p->fd);
+	THREAD_UNLOCK();	
 
 	argv[0] = "sh";
 	argv[1] = "-c";


### PR DESCRIPTION
Lock is missing when parsing pidlist which can cause undefined behavior and a seg fault in multithread applications.

Added locks to fix the issue.